### PR TITLE
rebuild 2.12.2 (Azure pipelines failed on first merge)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 319160a1e14479c69aa09060dd4e8b66fa1f9227a4649f9da58b93bcdef2f269
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Azure Windows + macOS builds failed on the 2.12.2 main build with transient GitHub/Azure sync errors (`fatal: couldn't find remote ref refs/pull/15/merge`). Linux (GHA) went through fine, so the conda-forge channel currently only has linux-64 binaries for 2.12.2.

Bumping the build number to 1 triggers a clean rebuild across all platforms.