### PR TITLE
Update unicorn-binance-local-depth-cache to 2.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-local-depth-cache" %}
-{% set version = "2.12.3" %}
+{% set version = "2.13.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_local_depth_cache-{{ version }}.tar.gz
-  sha256: 00b6fa40404873bbaa6149205c336c717440a49cc3b8d64367bb130a1a230946
+  sha256: 782c377fcb5063867e7f66c6bcd27e8cfe89cf51b7e1b9e48f7dd3a845efe1e6
 
 build:
   number: 0


### PR DESCRIPTION
Checklist
 - [x] Used a fork of the feedstock to propose changes
 - [x] Bumped the build number (if the version is unchanged) — n/a, version bumped
 - [x] Reset the build number to 0 (if the version changed) — was already 0
 - [x] Re-rendered with the latest conda-smithy — no recipe changes beyond version + sha, rerender not needed
 - [x] Ensured the license file is being packaged — unchanged
 - [x] Tested the recipe — upstream release built and published to PyPI

## Summary
- Version bump 2.12.3 → 2.13.0
- sha256 updated for the new sdist
- Dependencies match upstream \`setup.py\` (unchanged): aiohttp, cython >=3.0.10, orjson, requests >=2.32.3, unicorn-binance-websocket-api >=2.12.2, unicorn-binance-rest-api >=2.10.0

Upstream changelog: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/CHANGELOG.md#2130

Highlights:
- New \`BinanceLocalDepthCacheManager.set_credentials(api_key, api_secret)\` — swap the internal REST manager at runtime without dropping WebSocket streams. Enables UBDCC cluster credential rebalances.