### PR TITLE
update unicorn-binance-local-depth-cache to 2.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-local-depth-cache" %}
-{% set version = "2.13.0" %}
+{% set version = "2.14.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_local_depth_cache-{{ version }}.tar.gz
-  sha256: 782c377fcb5063867e7f66c6bcd27e8cfe89cf51b7e1b9e48f7dd3a845efe1e6
+  sha256: 09351c71a6984451aeb09de7544c977d8e6e71ee71792993f9f053a2a7d1d259
 
 build:
   number: 0


### PR DESCRIPTION
Bumps the feedstock from 2.13.0 to 2.14.0.

### Checklist for the recipe maintainer

- [x] Version bumped in `recipe/meta.yaml` (2.13.0 → 2.14.0)
- [x] sha256 updated to match the new PyPI sdist (`09351c71…d1d259` for `unicorn_binance_local_depth_cache-2.14.0.tar.gz`)
- [x] Build number reset to 0 (version bump)
- [x] Runtime dependencies unchanged — upstream `pyproject.toml` still pins `unicorn-binance-rest-api >=2.10.0`, `unicorn-binance-websocket-api >=2.12.2`, `requests >=2.32.3`; no new runtime deps introduced

### Upstream 2.14.0 highlights

- **Added**: Binance Cross Margin and Isolated Margin support (mainnet + testnet) in all four exchange switches in `manager.py` — snapshot fetch, live-update gap detection, post-sync buffer replay, init-phase sync-point search
- **Changed (breaking)**: cluster-client credential methods renamed (`cluster.ubdcc_*_credentials*` → `cluster.*_credentials*`) for API consistency; matching UBDCC cluster endpoints renamed too — pair with UBDCC ≥ 0.7.0

See https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/releases/tag/2.14.0 for full release notes.

@conda-forge-admin please rerender