### PR TITLE
Rebuild for python 3.14 osx (race-condition v2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 09351c71a6984451aeb09de7544c977d8e6e71ee71792993f9f053a2a7d1d259
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Second rebuild — the previous one raced again on osx_64.

After the first rebuild PR was merged, the osx_64 build started before UBWA's osx-py3.14 package had finished uploading (UBWA-osx took an extra build cycle due to a separate flaky macOS SDK download). The other platforms (linux+win) succeeded.

UBWA py3.14 is now fully live on all 3 platforms (linux/osx/win), so this rebuild should pick it up cleanly. Linux+win will be rebuilt as a side effect — they will overwrite the existing higher-build-number package and is harmless.